### PR TITLE
Reworked datetime parser to accept am / pm time formats, fixed some parsing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,11 @@ Usage:
             The given day at {hour}:{minute}
             e.g. 24.12. 12:00
             e.g. 7.4.   9:15
-            
+        
+        {day}.{month}.{year}
+            The given day at 7:00 am
+            e.g. 22.12.2020
+            e.g. 01.01.21
     
 Features
 --------

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ For the UI client, run `tod0` from anywhere on your terminal.
 For the CLI client, run `todocli` from anywhere on your terminal.
 Usage:
 
+    NAME
+        todocli - Command line client for Microsoft ToDo 
+        
     SYNOPSIS
         todocli [options] COMMAND ...  
         
@@ -91,7 +94,7 @@ Usage:
         
         If 'list_name' is omitted, the default task list will be used. 
         'task_number' is the position displayed when specifying option '-n'. 
-       
+           
     Specifying time:
         For options which take 'time' as a parameter, 'time' can be one of the following:
         
@@ -101,19 +104,33 @@ Usage:
             Max: 99h
             
         morning
-            Tomorrow morning at 07:00 AM
+            Today at 07:00 AM if current time < 07:00 AM, otherwise tomorrow
+
+        tomorrow
+            Tomorrow at 07:00 AM
             
         evening
-            Today at 06:00 PM if current time < 06:00 PM, otherwise tomorrow at 06:00 PM
+            Today at 06:00 PM if current time < 06:00 PM, otherwise tomorrow
             
         {hour}:{minute}
-            Today at {hour}:{minute}
+            Today at {hour}:{minute} if current time < {hour}:{minute}, otherwise tomorrow 
             e.g. 9:30, 09:30, 17:15
+            
+        {hour}:{minute} am|pm 
+            Today at {hour}:{minute} am|pm  if current time < {hour}:{minute} am|pm, otherwise tomorrow
+            e.g. 9:30 am, 12:00 am, 10:15 pm
             
         {day}.{month}. {hour}:{minute}
             The given day at {hour}:{minute}
             e.g. 24.12. 12:00
             e.g. 7.4.   9:15
+            
+        {month}/{day}. {hour}:{minute} am|pm
+            The given day at {hour}:{minute} am|pm
+            e.g. 12/24 12:00 pm
+            e.g. 03/02   9:15
+            e.g. 3/2   09:15
+
             
     
 Features

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Usage:
         
         If 'list_name' is omitted, the default task list will be used. 
         'task_number' is the position displayed when specifying option '-n'. 
-           
+       
     Specifying time:
         For options which take 'time' as a parameter, 'time' can be one of the following:
         
@@ -124,13 +124,6 @@ Usage:
             The given day at {hour}:{minute}
             e.g. 24.12. 12:00
             e.g. 7.4.   9:15
-            
-        {month}/{day}. {hour}:{minute} am|pm
-            The given day at {hour}:{minute} am|pm
-            e.g. 12/24 12:00 pm
-            e.g. 03/02   9:15
-            e.g. 3/2   09:15
-
             
     
 Features

--- a/todocli/cli.py
+++ b/todocli/cli.py
@@ -89,12 +89,7 @@ Specifying time:
         The given day at {hour}:{minute}
         e.g. 24.12. 12:00
         e.g. 7.4.   9:15
-        
-    {month}/{day}. {hour}:{minute} am|pm
-        The given day at {hour}:{minute} am|pm
-        e.g. 12/24 12:00 pm
-        e.g. 03/02   9:15
-        e.g. 3/2   09:15"""
+        """
 
 
 class InvalidTaskPath(Exception):

--- a/todocli/cli.py
+++ b/todocli/cli.py
@@ -4,7 +4,11 @@ import sys
 from typing import Optional, IO
 
 import todocli.todo_api as todo_api
-from todocli.datetime_parser import parse_datetime
+from todocli.datetime_parser import (
+    parse_datetime,
+    TimeExpressionNotRecognized,
+    ErrorParsingTime,
+)
 from todocli.error import error, eprint
 
 help_msg = """
@@ -65,19 +69,32 @@ Specifying time:
         Max: 99h
         
     morning
-        Tomorrow morning at 07:00 AM
+        Today at 07:00 AM if current time < 07:00 AM, otherwise tomorrow
         
     evening
-        Today at 06:00 PM if current time < 06:00 PM, otherwise tomorrow at 06:00 PM
+        Today at 06:00 PM if current time < 06:00 PM, otherwise tomorrow
+        
+    tomorrow
+        Tomorrow at 07:00 AM
         
     {hour}:{minute}
-        Today at {hour}:{minute}
+        Today at {hour}:{minute} if current time < {hour}:{minute}, otherwise tomorrow 
         e.g. 9:30, 09:30, 17:15
+        
+    {hour}:{minute} am|pm 
+        Today at {hour}:{minute} am|pm  if current time < {hour}:{minute} am|pm, otherwise tomorrow
+        e.g. 9:30 am, 12:00 am, 10:15 pm
         
     {day}.{month}. {hour}:{minute}
         The given day at {hour}:{minute}
         e.g. 24.12. 12:00
-        e.g. 7.4.   9:15"""
+        e.g. 7.4.   9:15
+        
+    {month}/{day}. {hour}:{minute} am|pm
+        The given day at {hour}:{minute} am|pm
+        e.g. 12/24 12:00 pm
+        e.g. 03/02   9:15
+        e.g. 3/2   09:15"""
 
 
 class InvalidTaskPath(Exception):
@@ -281,6 +298,10 @@ def main():
             except todo_api.TaskNotFoundByIndex as e:
                 eprint(e.message)
             except InvalidTaskPath as e:
+                eprint(e.message)
+            except TimeExpressionNotRecognized as e:
+                eprint(e.message)
+            except ErrorParsingTime as e:
                 eprint(e.message)
             finally:
                 sys.stdout.flush()

--- a/todocli/cli.py
+++ b/todocli/cli.py
@@ -89,6 +89,11 @@ Specifying time:
         The given day at {hour}:{minute}
         e.g. 24.12. 12:00
         e.g. 7.4.   9:15
+        
+    {day}.{month}.{year}
+        The given day at 7:00 am
+        e.g. 22.12.2020
+        e.g. 01.01.21
         """
 
 

--- a/todocli/datetime_parser.py
+++ b/todocli/datetime_parser.py
@@ -23,7 +23,8 @@ def parse_day_month_american(input_str):
     return day, month
 
 
-def add_day_if_datetime_is_in_past(dt: datetime) -> datetime:
+def add_day_if_past(dt: datetime) -> datetime:
+    """This function will add a day to the datetime object 'dt' when 'dt' is in the past"""
     dt_now = datetime.now()
     if dt < dt_now:
         return dt + timedelta(days=1)
@@ -51,7 +52,7 @@ def parse_datetime(datetime_str: str):
 
         if datetime_str == "morning":
             dt = datetime.now()
-            return add_day_if_datetime_is_in_past(
+            return add_day_if_past(
                 dt.replace(hour=7, minute=0, second=0, microsecond=0)
             )
 
@@ -63,7 +64,7 @@ def parse_datetime(datetime_str: str):
 
         if datetime_str == "evening":
             dt = datetime.now()
-            return add_day_if_datetime_is_in_past(
+            return add_day_if_past(
                 dt.replace(hour=18, minute=0, second=0, microsecond=0)
             )
 
@@ -79,7 +80,7 @@ def parse_datetime(datetime_str: str):
                     hour = 0
             else:
                 hour = hour + 12
-            return add_day_if_datetime_is_in_past(
+            return add_day_if_past(
                 datetime.now().replace(
                     hour=hour, minute=minute, second=0, microsecond=0
                 )
@@ -88,7 +89,7 @@ def parse_datetime(datetime_str: str):
         if re.match(r"([0-9]{1,2}:[0-9]{2})", datetime_str, re.IGNORECASE):
             """ e.g. 17:00 """
             hour, minute = parse_hour_minute(datetime_str)
-            return add_day_if_datetime_is_in_past(
+            return add_day_if_past(
                 datetime.now().replace(
                     hour=hour, minute=minute, second=0, microsecond=0
                 )

--- a/todocli/datetime_parser.py
+++ b/todocli/datetime_parser.py
@@ -16,24 +16,111 @@ def parse_day_month(input_str):
     return day, month
 
 
+def parse_day_month_american(input_str):
+    split_str = input_str.split("/")
+    month = int(split_str[0])
+    day = int(split_str[1])
+    return day, month
+
+
+def add_day_if_datetime_is_in_past(dt: datetime) -> datetime:
+    dt_now = datetime.now()
+    if dt < dt_now:
+        return dt + timedelta(days=1)
+    else:
+        return dt
+
+
+class TimeExpressionNotRecognized(Exception):
+    def __init__(self, time_str):
+        self.message = f"Time expression could not be parsed: {time_str}"
+        super(TimeExpressionNotRecognized, self).__init__(self.message)
+
+
+class ErrorParsingTime(Exception):
+    def __init__(self, message):
+        self.message = message
+        super(ErrorParsingTime, self).__init__(message)
+
+
 def parse_datetime(datetime_str: str):
-    if re.match(r"([0-9]{1,2}h)", datetime_str):
-        """ e.g. 1h / 12h """
-        return datetime.now() + timedelta(hours=int(datetime_str[:-1]))
-    if datetime_str == "morning":
-        return datetime.now().replace(hour=7) + timedelta(days=1)
-    if datetime_str == "evening":
-        dt = datetime.now()
-        if dt.hour > 18:
-            dt = dt + timedelta(days=1)
-        return dt.replace(hour=18)
-    if re.match(r"([0-9]{2}:[0-9]{2})", datetime_str):
-        """ e.g. 17:00 """
-        hour, minute = parse_hour_minute(datetime_str)
-        return datetime.now().replace(hour=hour, minute=minute)
-    if re.match(r"([0-9]{2}:[0-9]{2})", datetime_str):
-        """ e.g. 17.01. 17:00 """
-        split_str = datetime_str.split(" ")
-        day, month = parse_day_month(split_str[0])
-        hour, minute = parse_hour_minute(split_str[1])
-        return datetime.now().replace(day=day, month=month, hour=hour, minute=minute)
+    try:
+        if re.match(r"([0-9]{1,2}h)", datetime_str, re.IGNORECASE):
+            """ e.g. 1h / 12h """
+            return datetime.now() + timedelta(hours=int(datetime_str[:-1]))
+
+        if datetime_str == "morning":
+            dt = datetime.now()
+            return add_day_if_datetime_is_in_past(
+                dt.replace(hour=7, minute=0, second=0, microsecond=0)
+            )
+
+        if datetime_str == "tomorrow":
+            dt = datetime.now()
+            return dt.replace(hour=7, minute=0, second=0, microsecond=0) + timedelta(
+                days=1
+            )
+
+        if datetime_str == "evening":
+            dt = datetime.now()
+            return add_day_if_datetime_is_in_past(
+                dt.replace(hour=18, minute=0, second=0, microsecond=0)
+            )
+
+        if re.match(r"([0-9]{1,2}:[0-9]{2} (am|pm))", datetime_str, re.IGNORECASE):
+            """ e.g. 5:30 pm """
+            split_str = datetime_str.split(" ")
+            hour, minute = parse_hour_minute(split_str[0])
+
+            dt = datetime.now()
+
+            if split_str[1] == "am":
+                if hour == 12:
+                    hour = 0
+            else:
+                hour = hour + 12
+            return add_day_if_datetime_is_in_past(
+                datetime.now().replace(
+                    hour=hour, minute=minute, second=0, microsecond=0
+                )
+            )
+
+        if re.match(r"([0-9]{1,2}:[0-9]{2})", datetime_str, re.IGNORECASE):
+            """ e.g. 17:00 """
+            hour, minute = parse_hour_minute(datetime_str)
+            return add_day_if_datetime_is_in_past(
+                datetime.now().replace(
+                    hour=hour, minute=minute, second=0, microsecond=0
+                )
+            )
+
+        if re.match(
+            r"([0-9]{1,2}\.[0-9]{1,2}\. [0-9]{1,2}:[0-9]{2})",
+            datetime_str,
+            re.IGNORECASE,
+        ):
+            """ e.g. 17.01. 17:00 """
+            split_str = datetime_str.split(" ")
+            day, month = parse_day_month(split_str[0])
+            hour, minute = parse_hour_minute(split_str[1])
+            return datetime.now().replace(
+                day=day, month=month, hour=hour, minute=minute, second=0, microsecond=0
+            )
+
+        if re.match(
+            r"([0-9]{1,2}/[0-9]{1,2} [0-9]{1,2}:[0-9]{2} (am|pm))",
+            datetime_str,
+            re.IGNORECASE,
+        ):
+            """ e.g. 17.01. 17:00 """
+            split_str = datetime_str.split(" ")
+            day, month = parse_day_month_american(split_str[0])
+            hour, minute = parse_hour_minute(split_str[1])
+            return datetime.now().replace(
+                day=day, month=month, hour=hour, minute=minute, second=0, microsecond=0
+            )
+
+    except ValueError as e:
+        raise ErrorParsingTime(str(e))
+
+    raise TimeExpressionNotRecognized(datetime_str)

--- a/todocli/datetime_parser.py
+++ b/todocli/datetime_parser.py
@@ -128,18 +128,18 @@ def parse_datetime(datetime_str: str):
                 day=day, month=month, hour=hour, minute=minute, second=0, microsecond=0
             )
 
-        if re.match(
-            r"([0-9]{1,2}/[0-9]{1,2} [0-9]{1,2}:[0-9]{2} (am|pm))",
-            datetime_str,
-            re.IGNORECASE,
-        ):
-            """ e.g. 17/01 5:00 pm """
-            split_str = datetime_str.split(" ")
-            day, month = parse_day_month_MM_DD(split_str[0])
-            hour, minute = parse_hour_minute(split_str[1])
-            return datetime.now().replace(
-                day=day, month=month, hour=hour, minute=minute, second=0, microsecond=0
-            )
+        # if re.match(
+        #     r"([0-9]{1,2}/[0-9]{1,2} [0-9]{1,2}:[0-9]{2} (am|pm))",
+        #     datetime_str,
+        #     re.IGNORECASE,
+        # ):
+        #     """ e.g. 01/17 5:00 pm """
+        #     split_str = datetime_str.split(" ")
+        #     day, month = parse_day_month_MM_DD(split_str[0])
+        #     hour, minute = parse_hour_minute(split_str[1])
+        #     return datetime.now().replace(
+        #         day=day, month=month, hour=hour, minute=minute, second=0, microsecond=0
+        #     )
 
     except ValueError as e:
         raise ErrorParsingTime(str(e))

--- a/todocli/datetime_parser.py
+++ b/todocli/datetime_parser.py
@@ -22,6 +22,16 @@ def parse_day_month_MM_DD(input_str):
     day = int(split_str[1])
     return day, month
 
+def parse_day_month_DD_MM_YYorYYYY(input_str):
+    split_str = input_str.split(".")
+    day = int(split_str[0])
+    month = int(split_str[1])
+    year = split_str[2]
+    if len(year) == 2:
+        year = int("20"+year)
+    else:
+        year = int(year)
+    return day,month,year
 
 def add_day_if_past(dt: datetime) -> datetime:
     """This function will add a day to the datetime object 'dt' when 'dt' is in the past"""
@@ -92,6 +102,17 @@ def parse_datetime(datetime_str: str):
                 datetime.now().replace(
                     hour=hour, minute=minute, second=0, microsecond=0
                 )
+            )
+
+        if re.match(
+            r"([0-9]{1,2}\.[0-9]{1,2}\.(([0-9]{4})|([0-9]{2})))$",
+            datetime_str,
+            re.IGNORECASE,
+        ):
+            """ e.g. 17.01.20 or 22.12.2020 """
+            day, month, year = parse_day_month_DD_MM_YYorYYYY(datetime_str)
+            return datetime.now().replace(
+                year=year, day=day, month=month, hour=7, minute=0, second=0, microsecond=0
             )
 
         if re.match(

--- a/todocli/datetime_parser.py
+++ b/todocli/datetime_parser.py
@@ -9,14 +9,14 @@ def parse_hour_minute(input_str):
     return hour, minute
 
 
-def parse_day_month(input_str):
+def parse_day_month_DD_MM(input_str):
     split_str = input_str.split(".")
     day = int(split_str[0])
     month = int(split_str[1])
     return day, month
 
 
-def parse_day_month_american(input_str):
+def parse_day_month_MM_DD(input_str):
     split_str = input_str.split("/")
     month = int(split_str[0])
     day = int(split_str[1])
@@ -73,13 +73,12 @@ def parse_datetime(datetime_str: str):
             split_str = datetime_str.split(" ")
             hour, minute = parse_hour_minute(split_str[0])
 
-            dt = datetime.now()
-
             if split_str[1] == "am":
                 if hour == 12:
                     hour = 0
             else:
                 hour = hour + 12
+
             return add_day_if_past(
                 datetime.now().replace(
                     hour=hour, minute=minute, second=0, microsecond=0
@@ -102,7 +101,7 @@ def parse_datetime(datetime_str: str):
         ):
             """ e.g. 17.01. 17:00 """
             split_str = datetime_str.split(" ")
-            day, month = parse_day_month(split_str[0])
+            day, month = parse_day_month_DD_MM(split_str[0])
             hour, minute = parse_hour_minute(split_str[1])
             return datetime.now().replace(
                 day=day, month=month, hour=hour, minute=minute, second=0, microsecond=0
@@ -113,9 +112,9 @@ def parse_datetime(datetime_str: str):
             datetime_str,
             re.IGNORECASE,
         ):
-            """ e.g. 17.01. 17:00 """
+            """ e.g. 17/01 5:00 pm """
             split_str = datetime_str.split(" ")
-            day, month = parse_day_month_american(split_str[0])
+            day, month = parse_day_month_MM_DD(split_str[0])
             hour, minute = parse_hour_minute(split_str[1])
             return datetime.now().replace(
                 day=day, month=month, hour=hour, minute=minute, second=0, microsecond=0

--- a/todocli/datetime_parser.py
+++ b/todocli/datetime_parser.py
@@ -22,16 +22,18 @@ def parse_day_month_MM_DD(input_str):
     day = int(split_str[1])
     return day, month
 
+
 def parse_day_month_DD_MM_YYorYYYY(input_str):
     split_str = input_str.split(".")
     day = int(split_str[0])
     month = int(split_str[1])
     year = split_str[2]
     if len(year) == 2:
-        year = int("20"+year)
+        year = int("20" + year)
     else:
         year = int(year)
-    return day,month,year
+    return day, month, year
+
 
 def add_day_if_past(dt: datetime) -> datetime:
     """This function will add a day to the datetime object 'dt' when 'dt' is in the past"""
@@ -112,7 +114,13 @@ def parse_datetime(datetime_str: str):
             """ e.g. 17.01.20 or 22.12.2020 """
             day, month, year = parse_day_month_DD_MM_YYorYYYY(datetime_str)
             return datetime.now().replace(
-                year=year, day=day, month=month, hour=7, minute=0, second=0, microsecond=0
+                year=year,
+                day=day,
+                month=month,
+                hour=7,
+                minute=0,
+                second=0,
+                microsecond=0,
             )
 
         if re.match(

--- a/todocli/test/test_datetime_parser.py
+++ b/todocli/test/test_datetime_parser.py
@@ -20,21 +20,21 @@ class TestDatetimeParser(unittest.TestCase):
         dt = add_day_if_past(dt)
         assert dt.day == dt_now.day
 
-    def test_american_time1(self):
+    def test_am_pm_time1(self):
         input_str = "07:00 pm"
         dt = parse_datetime(input_str)
         dt_expected = datetime.now().replace(hour=19, minute=0, second=0, microsecond=0)
         dt_expected = add_day_if_past(dt_expected)
         assert dt == dt_expected
 
-    def test_american_time2(self):
+    def test_am_pm_time2(self):
         input_str = "7:00 pm"
         dt = parse_datetime(input_str)
         dt_expected = datetime.now().replace(hour=19, minute=0, second=0, microsecond=0)
         dt_expected = add_day_if_past(dt_expected)
         assert dt == dt_expected
 
-    def test_american_time3(self):
+    def test_am_pm_time3(self):
         input_str = "12:00 am"
         dt = parse_datetime(input_str)
         dt_expected = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -60,16 +60,16 @@ class TestDatetimeParser(unittest.TestCase):
             "24.6. 12:00",
             "6.6. 06:06",
             "6.6. 6:06",
-            "04/27 12:00 am",
-            "04/27 2:00 am",
-            "04/27 3:00 pm",
-            "04/27 10:00 pm",
-            "4/27 10:00 pm",
-            "4/27 09:00 pm",
-            "4/27 9:00 pm",
-            "4/4 9:00 pm",
-            "4/4 09:00 pm",
-            "4/4 12:00 pm",
+            # "04/27 12:00 am",
+            # "04/27 2:00 am",
+            # "04/27 3:00 pm",
+            # "04/27 10:00 pm",
+            # "4/27 10:00 pm",
+            # "4/27 09:00 pm",
+            # "4/27 9:00 pm",
+            # "4/4 9:00 pm",
+            # "4/4 09:00 pm",
+            # "4/4 12:00 pm",
             "morning",
             "evening",
             "tomorrow",

--- a/todocli/test/test_datetime_parser.py
+++ b/todocli/test/test_datetime_parser.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from todocli.datetime_parser import (
     parse_datetime,
-    add_day_if_datetime_is_in_past,
+    add_day_if_past,
     ErrorParsingTime,
     TimeExpressionNotRecognized,
 )
@@ -13,32 +13,32 @@ class TestDatetimeParser(unittest.TestCase):
     def test_sadd_day_if_datetime_is_in_past(self):
         dt_now = datetime.now()
         dt = dt_now - timedelta(minutes=1)
-        dt = add_day_if_datetime_is_in_past(dt)
+        dt = add_day_if_past(dt)
         assert dt.day > dt_now.day
 
         dt = dt_now + timedelta(hours=1)
-        dt = add_day_if_datetime_is_in_past(dt)
+        dt = add_day_if_past(dt)
         assert dt.day == dt_now.day
 
     def test_american_time1(self):
         input_str = "07:00 pm"
         dt = parse_datetime(input_str)
         dt_expected = datetime.now().replace(hour=19, minute=0, second=0, microsecond=0)
-        dt_expected = add_day_if_datetime_is_in_past(dt_expected)
+        dt_expected = add_day_if_past(dt_expected)
         assert dt == dt_expected
 
     def test_american_time2(self):
         input_str = "7:00 pm"
         dt = parse_datetime(input_str)
         dt_expected = datetime.now().replace(hour=19, minute=0, second=0, microsecond=0)
-        dt_expected = add_day_if_datetime_is_in_past(dt_expected)
+        dt_expected = add_day_if_past(dt_expected)
         assert dt == dt_expected
 
     def test_american_time3(self):
         input_str = "12:00 am"
         dt = parse_datetime(input_str)
         dt_expected = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        dt_expected = add_day_if_datetime_is_in_past(dt_expected)
+        dt_expected = add_day_if_past(dt_expected)
         assert dt == dt_expected
 
     def test_time_strings(self):

--- a/todocli/test/test_datetime_parser.py
+++ b/todocli/test/test_datetime_parser.py
@@ -1,0 +1,106 @@
+import unittest
+from datetime import datetime, timedelta
+
+from todocli.datetime_parser import (
+    parse_datetime,
+    add_day_if_datetime_is_in_past,
+    ErrorParsingTime,
+    TimeExpressionNotRecognized,
+)
+
+
+class TestDatetimeParser(unittest.TestCase):
+    def test_sadd_day_if_datetime_is_in_past(self):
+        dt_now = datetime.now()
+        dt = dt_now - timedelta(minutes=1)
+        dt = add_day_if_datetime_is_in_past(dt)
+        assert dt.day > dt_now.day
+
+        dt = dt_now + timedelta(hours=1)
+        dt = add_day_if_datetime_is_in_past(dt)
+        assert dt.day == dt_now.day
+
+    def test_american_time1(self):
+        input_str = "07:00 pm"
+        dt = parse_datetime(input_str)
+        dt_expected = datetime.now().replace(hour=19, minute=0, second=0, microsecond=0)
+        dt_expected = add_day_if_datetime_is_in_past(dt_expected)
+        assert dt == dt_expected
+
+    def test_american_time2(self):
+        input_str = "7:00 pm"
+        dt = parse_datetime(input_str)
+        dt_expected = datetime.now().replace(hour=19, minute=0, second=0, microsecond=0)
+        dt_expected = add_day_if_datetime_is_in_past(dt_expected)
+        assert dt == dt_expected
+
+    def test_american_time3(self):
+        input_str = "12:00 am"
+        dt = parse_datetime(input_str)
+        dt_expected = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        dt_expected = add_day_if_datetime_is_in_past(dt_expected)
+        assert dt == dt_expected
+
+    def test_time_strings(self):
+        times = [
+            "07:00",
+            "7:00",
+            "0:00",
+            "17:30",
+            "6:30 am",
+            "6:30 pm",
+            "06:30 am",
+            "06:30 pm",
+            "00:00 am",
+            "12:00 am",
+            "24.06. 12:00",
+            "24.06. 6:00",
+            "24.6. 6:00",
+            "24.6. 06:00",
+            "24.6. 12:00",
+            "6.6. 06:06",
+            "6.6. 6:06",
+            "04/27 12:00 am",
+            "04/27 2:00 am",
+            "04/27 3:00 pm",
+            "04/27 10:00 pm",
+            "4/27 10:00 pm",
+            "4/27 09:00 pm",
+            "4/27 9:00 pm",
+            "4/4 9:00 pm",
+            "4/4 09:00 pm",
+            "4/4 12:00 pm",
+            "morning",
+            "evening",
+            "tomorrow",
+        ]
+
+        for time in times:
+            print(f"testing time: {time}")
+            parse_datetime(time)
+
+    def test_invalid_time(self):
+        invalid_times = [
+            "24:00",
+            "25:00",
+            "25123:00",
+            "0:12345",
+            "12:30 sam",
+            "12:30 pom",
+            "abfdsa",
+        ]
+
+        for time in invalid_times:
+            print(f"testing time: {time}")
+            try:
+                self.assertRaises(Exception, parse_datetime(time))
+            except ErrorParsingTime:
+                pass
+            except TimeExpressionNotRecognized:
+                pass
+            else:
+                raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todocli/test/test_datetime_parser.py
+++ b/todocli/test/test_datetime_parser.py
@@ -10,7 +10,7 @@ from todocli.datetime_parser import (
 
 
 class TestDatetimeParser(unittest.TestCase):
-    def test_sadd_day_if_datetime_is_in_past(self):
+    def test_add_day_if_datetime_is_in_past(self):
         dt_now = datetime.now()
         dt = dt_now - timedelta(minutes=1)
         dt = add_day_if_past(dt)


### PR DESCRIPTION
I reworked the datetime parser to allow the parsing of time strings in "am / pm 12 hour" format.
I also added some unit tests for the parser.

I updated the help text and README.md accordingly.
The new time expressions, which can now be parsed into a datetime object, include:

    7:45 am
    12:30 pm
    etc
