### PR TITLE
Print usage when no argument is provided

### DIFF
--- a/todocli/cli.py
+++ b/todocli/cli.py
@@ -264,10 +264,12 @@ def main():
                 namespace, args = parser.parse_known_args()
                 parser.parse_args(args, namespace)
 
-                namespace.func(namespace)
+                if namespace.func is not None:
+                    namespace.func(namespace)
+                else:
+                    # No argument was provided
+                    parser.print_usage()
 
-            except TypeError:
-                parser.print_help()
             except argparse.ArgumentError:
                 pass
             except ArgumentParser.OnExit:


### PR DESCRIPTION
Reworked what happens when no argument is provided.

Before a try...except block caught a TypeError when trying to call namespace.func (because namespace.func was None).
However, this will also catch type errors that can happen otherwise in the code.

Now: Explicitly check if namespace.func is None. 
If it is, print the usage message instead of the help message.