### PR TITLE
Add subtasks (checklist items) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Usage:
         'COMMAND' can be one of the following values:
             ls                  Display all lists  
             
-            lst <list_name>     Display all tasks from list
+            lst <list_name> [-s] Display all tasks from list
                 list_name       Name of the list
+                -s, --steps     Also display checklist items (steps) for each task
                 
             new <task> [-r time]
                                 Create a new task
@@ -74,6 +75,24 @@ Usage:
                
             rm <task>           Remove a task
                 task            Task to remove. See 'Specifying a task' for details.
+
+            new-step <task> <step>
+                                Add a step (checklist item) to a task
+                task            Task to add step to. See 'Specifying a task' for details.
+                step            Description of the step to create.
+
+            list-steps <task>   Display steps (checklist items) of a task
+                task            Task to display steps for. See 'Specifying a task' for details.
+
+            complete-step <task> <step>
+                                Mark a step as checked
+                task            Task containing the step. See 'Specifying a task' for details.
+                step            Step to complete (name or index number).
+
+            rm-step <task> <step>
+                                Remove a step from a task
+                task            Task containing the step. See 'Specifying a task' for details.
+                step            Step to remove (name or index number).
                    
     OPTIONS
         -h, --help
@@ -141,3 +160,4 @@ Features
 - View folders and tasks
 - Create folders and tasks
 - Mark tasks as complete
+- Manage subtasks (checklist items / steps)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -22,6 +22,9 @@ if __name__ == "__main__":
     suite.addTests(loader.loadTestsFromName("tests.test_cli_commands"))
     suite.addTests(loader.loadTestsFromName("tests.test_models"))
     suite.addTests(loader.loadTestsFromName("tests.test_wrapper"))
+    suite.addTests(loader.loadTestsFromName("tests.test_checklist_item_model"))
+    suite.addTests(loader.loadTestsFromName("tests.test_checklist_wrapper"))
+    suite.addTests(loader.loadTestsFromName("tests.test_checklist_cli"))
 
     runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(suite)

--- a/tests/test_checklist_cli.py
+++ b/tests/test_checklist_cli.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Unit tests for checklist CLI commands (argument parsing)"""
+
+import unittest
+from todocli.cli import setup_parser
+
+
+class TestChecklistCLIArgParsing(unittest.TestCase):
+    """Test that CLI parsers correctly parse checklist command arguments"""
+
+    def setUp(self):
+        self.parser = setup_parser()
+
+    # new-step
+
+    def test_new_step_basic(self):
+        """Test new-step command with list/task format"""
+        args = self.parser.parse_args(
+            ["new-step", "Shopping/Buy groceries", "Buy eggs"]
+        )
+        self.assertEqual(args.task_name, "Shopping/Buy groceries")
+        self.assertEqual(args.step_name, "Buy eggs")
+
+    def test_new_step_default_list(self):
+        """Test new-step command without list prefix"""
+        args = self.parser.parse_args(["new-step", "Buy groceries", "Buy eggs"])
+        self.assertEqual(args.task_name, "Buy groceries")
+        self.assertEqual(args.step_name, "Buy eggs")
+
+    def test_new_step_with_list_flag(self):
+        """Test new-step with --list flag"""
+        args = self.parser.parse_args(
+            ["new-step", "Buy groceries", "Buy eggs", "-l", "Shopping"]
+        )
+        self.assertEqual(args.task_name, "Buy groceries")
+        self.assertEqual(args.step_name, "Buy eggs")
+        self.assertEqual(args.list, "Shopping")
+
+    # list-steps
+
+    def test_list_steps_basic(self):
+        """Test list-steps command with list/task format"""
+        args = self.parser.parse_args(["list-steps", "Shopping/Buy groceries"])
+        self.assertEqual(args.task_name, "Shopping/Buy groceries")
+
+    def test_list_steps_default_list(self):
+        """Test list-steps without list prefix"""
+        args = self.parser.parse_args(["list-steps", "Buy groceries"])
+        self.assertEqual(args.task_name, "Buy groceries")
+
+    def test_list_steps_with_list_flag(self):
+        """Test list-steps with --list flag"""
+        args = self.parser.parse_args(["list-steps", "Buy groceries", "-l", "Shopping"])
+        self.assertEqual(args.task_name, "Buy groceries")
+        self.assertEqual(args.list, "Shopping")
+
+    # complete-step
+
+    def test_complete_step_basic(self):
+        """Test complete-step command"""
+        args = self.parser.parse_args(
+            ["complete-step", "Shopping/Buy groceries", "Buy eggs"]
+        )
+        self.assertEqual(args.task_name, "Shopping/Buy groceries")
+        self.assertEqual(args.step_name, "Buy eggs")
+
+    def test_complete_step_by_index(self):
+        """Test complete-step with numeric step index"""
+        args = self.parser.parse_args(["complete-step", "Shopping/Buy groceries", "0"])
+        self.assertEqual(args.step_name, "0")
+
+    def test_complete_step_with_list_flag(self):
+        """Test complete-step with --list flag"""
+        args = self.parser.parse_args(
+            ["complete-step", "Buy groceries", "Buy eggs", "-l", "Shopping"]
+        )
+        self.assertEqual(args.task_name, "Buy groceries")
+        self.assertEqual(args.step_name, "Buy eggs")
+        self.assertEqual(args.list, "Shopping")
+
+    # rm-step
+
+    def test_rm_step_basic(self):
+        """Test rm-step command"""
+        args = self.parser.parse_args(["rm-step", "Shopping/Buy groceries", "Buy eggs"])
+        self.assertEqual(args.task_name, "Shopping/Buy groceries")
+        self.assertEqual(args.step_name, "Buy eggs")
+
+    def test_rm_step_by_index(self):
+        """Test rm-step with numeric step index"""
+        args = self.parser.parse_args(["rm-step", "Shopping/Buy groceries", "2"])
+        self.assertEqual(args.step_name, "2")
+
+    def test_rm_step_with_list_flag(self):
+        """Test rm-step with --list flag"""
+        args = self.parser.parse_args(
+            ["rm-step", "Buy groceries", "Buy eggs", "-l", "Shopping"]
+        )
+        self.assertEqual(args.task_name, "Buy groceries")
+        self.assertEqual(args.step_name, "Buy eggs")
+        self.assertEqual(args.list, "Shopping")
+
+    # lst --steps flag
+
+    def test_lst_steps_flag(self):
+        """Test lst command with --steps flag"""
+        args = self.parser.parse_args(["lst", "Shopping", "-s"])
+        self.assertEqual(args.list_name, "Shopping")
+        self.assertTrue(args.steps)
+
+    def test_lst_steps_flag_long(self):
+        """Test lst command with --steps long flag"""
+        args = self.parser.parse_args(["lst", "Shopping", "--steps"])
+        self.assertTrue(args.steps)
+
+    def test_lst_no_steps_flag(self):
+        """Test lst command without --steps defaults to False"""
+        args = self.parser.parse_args(["lst", "Shopping"])
+        self.assertFalse(args.steps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_checklist_item_model.py
+++ b/tests/test_checklist_item_model.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Unit tests for ChecklistItem model"""
+
+import unittest
+from todocli.models.checklistitem import ChecklistItem
+
+
+class TestChecklistItemModel(unittest.TestCase):
+    """Test ChecklistItem model initialization and properties"""
+
+    def test_basic_item_creation(self):
+        """Test creating a ChecklistItem from API response"""
+        api_response = {
+            "id": "step123",
+            "displayName": "Buy eggs",
+            "isChecked": False,
+            "createdDateTime": "2024-01-25T10:00:00.0000000Z",
+        }
+        item = ChecklistItem(api_response)
+
+        self.assertEqual(item.id, "step123")
+        self.assertEqual(item.display_name, "Buy eggs")
+        self.assertFalse(item.is_checked)
+        self.assertIsNotNone(item.created_datetime)
+        self.assertIsNone(item.checked_datetime)
+
+    def test_checked_item(self):
+        """Test creating a checked ChecklistItem"""
+        api_response = {
+            "id": "step456",
+            "displayName": "Buy milk",
+            "isChecked": True,
+            "createdDateTime": "2024-01-25T10:00:00.0000000Z",
+            "checkedDateTime": "2024-01-25T11:00:00.0000000Z",
+        }
+        item = ChecklistItem(api_response)
+
+        self.assertTrue(item.is_checked)
+        self.assertIsNotNone(item.checked_datetime)
+
+    def test_unchecked_item_no_checked_datetime(self):
+        """Test that unchecked item has no checked_datetime"""
+        api_response = {
+            "id": "step789",
+            "displayName": "Buy bread",
+            "isChecked": False,
+            "createdDateTime": "2024-01-25T10:00:00.0000000Z",
+        }
+        item = ChecklistItem(api_response)
+
+        self.assertFalse(item.is_checked)
+        self.assertIsNone(item.checked_datetime)
+
+    def test_checked_datetime_null_value(self):
+        """Test that null checkedDateTime is handled as None"""
+        api_response = {
+            "id": "step101",
+            "displayName": "Clean kitchen",
+            "isChecked": False,
+            "createdDateTime": "2024-01-25T10:00:00.0000000Z",
+            "checkedDateTime": None,
+        }
+        item = ChecklistItem(api_response)
+
+        self.assertFalse(item.is_checked)
+        self.assertIsNone(item.checked_datetime)
+
+    def test_display_name_preserved(self):
+        """Test that display name with special characters is preserved"""
+        api_response = {
+            "id": "step201",
+            "displayName": "Check A/B testing results (urgent!)",
+            "isChecked": False,
+            "createdDateTime": "2024-01-25T10:00:00.0000000Z",
+        }
+        item = ChecklistItem(api_response)
+
+        self.assertEqual(item.display_name, "Check A/B testing results (urgent!)")
+
+    def test_datetime_without_fractional_seconds(self):
+        """Test parsing datetime without fractional seconds (checklistItems API format)"""
+        api_response = {
+            "id": "step301",
+            "displayName": "Step",
+            "isChecked": True,
+            "createdDateTime": "2026-02-04T19:08:45Z",
+            "checkedDateTime": "2026-02-04T19:10:00Z",
+        }
+        item = ChecklistItem(api_response)
+
+        self.assertIsNotNone(item.created_datetime)
+        self.assertIsNotNone(item.checked_datetime)
+
+    def test_datetime_with_fractional_seconds(self):
+        """Test parsing datetime with fractional seconds (standard Graph API format)"""
+        api_response = {
+            "id": "step401",
+            "displayName": "Step",
+            "isChecked": False,
+            "createdDateTime": "2024-01-25T10:00:00.0000000Z",
+        }
+        item = ChecklistItem(api_response)
+
+        self.assertIsNotNone(item.created_datetime)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_checklist_wrapper.py
+++ b/tests/test_checklist_wrapper.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Unit tests for checklist item wrapper functions"""
+
+import unittest
+from todocli.graphapi.wrapper import (
+    StepNotFoundByName,
+    StepNotFoundByIndex,
+    BASE_URL,
+)
+
+
+class TestStepExceptions(unittest.TestCase):
+    """Test step-related exception classes"""
+
+    def test_step_not_found_by_name_exception(self):
+        """Test StepNotFoundByName exception message"""
+        step_name = "NonExistentStep"
+        task_name = "Buy groceries"
+        exc = StepNotFoundByName(step_name, task_name)
+
+        self.assertIn(step_name, exc.message)
+        self.assertIn(task_name, exc.message)
+        self.assertIn("could not be found", exc.message)
+
+    def test_step_not_found_by_index_exception(self):
+        """Test StepNotFoundByIndex exception message"""
+        step_index = 999
+        task_name = "Buy groceries"
+        exc = StepNotFoundByIndex(step_index, task_name)
+
+        self.assertIn(str(step_index), exc.message)
+        self.assertIn(task_name, exc.message)
+        self.assertIn("could not be found", exc.message)
+
+
+class TestChecklistEndpointPattern(unittest.TestCase):
+    """Test that the checklist endpoint URL is correctly constructed"""
+
+    def test_checklist_endpoint_format(self):
+        """Test the checklistItems endpoint follows the expected pattern"""
+        list_id = "list123"
+        task_id = "task456"
+        endpoint = f"{BASE_URL}/{list_id}/tasks/{task_id}/checklistItems"
+
+        self.assertIn("checklistItems", endpoint)
+        self.assertIn(list_id, endpoint)
+        self.assertIn(task_id, endpoint)
+        self.assertTrue(endpoint.startswith("https://graph.microsoft.com"))
+
+    def test_checklist_item_endpoint_format(self):
+        """Test individual checklistItem endpoint format"""
+        list_id = "list123"
+        task_id = "task456"
+        step_id = "step789"
+        endpoint = f"{BASE_URL}/{list_id}/tasks/{task_id}/checklistItems/{step_id}"
+
+        self.assertIn(step_id, endpoint)
+        self.assertTrue(endpoint.endswith(step_id))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todocli/graphapi/wrapper.py
+++ b/todocli/graphapi/wrapper.py
@@ -9,6 +9,7 @@ from typing import Union
 
 from todocli.models.todolist import TodoList
 from todocli.models.todotask import Task, TaskStatus
+from todocli.models.checklistitem import ChecklistItem
 from todocli.graphapi.oauth import get_oauth_session
 
 from todocli.utils.datetime_util import datetime_to_api_timestamp
@@ -39,6 +40,22 @@ class TaskNotFoundByIndex(Exception):
             task_index, list_name
         )
         super(TaskNotFoundByIndex, self).__init__(self.message)
+
+
+class StepNotFoundByName(Exception):
+    def __init__(self, step_name, task_name):
+        self.message = "Step with name '{}' could not be found in task '{}'".format(
+            step_name, task_name
+        )
+        super(StepNotFoundByName, self).__init__(self.message)
+
+
+class StepNotFoundByIndex(Exception):
+    def __init__(self, step_index, task_name):
+        self.message = "Step with index '{}' could not be found in task '{}'".format(
+            step_index, task_name
+        )
+        super(StepNotFoundByIndex, self).__init__(self.message)
 
 
 def parse_response(response):
@@ -198,5 +215,115 @@ def get_task_id_by_name(list_name: str, task_name: str):
     #        return tasks[task_list_position].id
     #    except IndexError:
     #        raise TaskNotFoundByIndex(task_list_position, list_name)
+    else:
+        raise
+
+
+def get_checklist_items(
+    list_name: str = None,
+    task_name: Union[str, int] = None,
+    list_id: str = None,
+    task_id: str = None,
+):
+    assert (list_name is not None) or (
+        list_id is not None
+    ), "You must provide list_name or list_id"
+    assert (task_name is not None) or (
+        task_id is not None
+    ), "You must provide task_name or task_id"
+
+    if list_id is None:
+        list_id = get_list_id_by_name(list_name)
+    if task_id is None:
+        task_id = get_task_id_by_name(list_name, task_name)
+
+    endpoint = f"{BASE_URL}/{list_id}/tasks/{task_id}/checklistItems"
+    session = get_oauth_session()
+    response = session.get(endpoint)
+    response_value = parse_response(response)
+    return [ChecklistItem(x) for x in response_value]
+
+
+def create_checklist_item(
+    step_name: str,
+    list_name: str = None,
+    task_name: Union[str, int] = None,
+    list_id: str = None,
+    task_id: str = None,
+):
+    assert (list_name is not None) or (
+        list_id is not None
+    ), "You must provide list_name or list_id"
+    assert (task_name is not None) or (
+        task_id is not None
+    ), "You must provide task_name or task_id"
+
+    if list_id is None:
+        list_id = get_list_id_by_name(list_name)
+    if task_id is None:
+        task_id = get_task_id_by_name(list_name, task_name)
+
+    endpoint = f"{BASE_URL}/{list_id}/tasks/{task_id}/checklistItems"
+    request_body = {"displayName": step_name}
+    session = get_oauth_session()
+    response = session.post(endpoint, json=request_body)
+    return True if response.ok else response.raise_for_status()
+
+
+def complete_checklist_item(
+    list_name: str, task_name: Union[str, int], step_name: Union[str, int]
+):
+    list_id = get_list_id_by_name(list_name)
+    task_id = get_task_id_by_name(list_name, task_name)
+    step_id = get_step_id(
+        list_name, task_name, step_name, list_id=list_id, task_id=task_id
+    )
+
+    endpoint = f"{BASE_URL}/{list_id}/tasks/{task_id}/checklistItems/{step_id}"
+    request_body = {"isChecked": True}
+    session = get_oauth_session()
+    response = session.patch(endpoint, json=request_body)
+    return True if response.ok else response.raise_for_status()
+
+
+def delete_checklist_item(
+    list_name: str, task_name: Union[str, int], step_name: Union[str, int]
+):
+    list_id = get_list_id_by_name(list_name)
+    task_id = get_task_id_by_name(list_name, task_name)
+    step_id = get_step_id(
+        list_name, task_name, step_name, list_id=list_id, task_id=task_id
+    )
+
+    endpoint = f"{BASE_URL}/{list_id}/tasks/{task_id}/checklistItems/{step_id}"
+    session = get_oauth_session()
+    response = session.delete(endpoint)
+    return True if response.ok else response.raise_for_status()
+
+
+def get_step_id(
+    list_name: str,
+    task_name: Union[str, int],
+    step_name: Union[str, int],
+    list_id: str = None,
+    task_id: str = None,
+):
+    if list_id is None:
+        list_id = get_list_id_by_name(list_name)
+    if task_id is None:
+        task_id = get_task_id_by_name(list_name, task_name)
+
+    items = get_checklist_items(list_id=list_id, task_id=task_id)
+
+    if isinstance(step_name, int):
+        try:
+            return items[step_name].id
+        except IndexError:
+            raise StepNotFoundByIndex(step_name, task_name)
+    elif isinstance(step_name, str):
+        for item in items:
+            if item.display_name == step_name:
+                return item.id
+        raise StepNotFoundByName(step_name, task_name)
     else:
         raise

--- a/todocli/help_msg.py
+++ b/todocli/help_msg.py
@@ -8,8 +8,9 @@ SYNOPSIS
     'COMMAND' can be one of the following values:
         ls                  Display all lists  
 
-        lst <list_name>     Display all tasks from list
+        lst <list_name> [-s] Display all tasks from list
             list_name       Name of the list
+            -s, --steps     Also display checklist items (steps) for each task
 
         new <task> [-r time]
                             Create a new task
@@ -24,6 +25,24 @@ SYNOPSIS
 
         rm <task>           Remove a task
             task            Task to remove. See 'Specifying a task' for details.
+
+        new-step <task> <step>
+                            Add a step (checklist item) to a task
+            task            Task to add step to. See 'Specifying a task' for details.
+            step            Description of the step to create.
+
+        list-steps <task>   Display steps (checklist items) of a task
+            task            Task to display steps for. See 'Specifying a task' for details.
+
+        complete-step <task> <step>
+                            Mark a step as checked
+            task            Task containing the step. See 'Specifying a task' for details.
+            step            Step to complete (name or index number).
+
+        rm-step <task> <step>
+                            Remove a step from a task
+            task            Task containing the step. See 'Specifying a task' for details.
+            step            Step to remove (name or index number).
 
 OPTIONS
     -h, --help

--- a/todocli/models/checklistitem.py
+++ b/todocli/models/checklistitem.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timezone
+
+
+def _parse_datetime(dt_str):
+    """Parse datetime string from checklist items API.
+
+    The checklistItems endpoint returns datetimes without fractional seconds
+    (e.g. "2026-02-04T19:08:45Z"), unlike tasks which include 7 digits
+    (e.g. "2024-01-25T10:00:00.0000000Z").
+    """
+    if dt_str is None:
+        return None
+
+    if isinstance(dt_str, dict):
+        dt_str = dt_str["dateTime"]
+
+    # Strip trailing Z
+    dt_str = dt_str.rstrip("Z")
+
+    # Truncate fractional seconds to 6 digits (Python's %f limit)
+    if "." in dt_str:
+        base, frac = dt_str.rsplit(".", 1)
+        dt_str = f"{base}.{frac[:6]}"
+
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            dt = datetime.strptime(dt_str, fmt)
+            return dt.replace(tzinfo=timezone.utc).astimezone(tz=None)
+        except ValueError:
+            continue
+
+    return None
+
+
+class ChecklistItem:
+    def __init__(self, query_result):
+        self.id: str = query_result["id"]
+        self.display_name: str = query_result["displayName"]
+        self.is_checked: bool = bool(query_result["isChecked"])
+        self.created_datetime = _parse_datetime(query_result["createdDateTime"])
+
+        if "checkedDateTime" in query_result and query_result["checkedDateTime"]:
+            self.checked_datetime = _parse_datetime(query_result["checkedDateTime"])
+        else:
+            self.checked_datetime = None


### PR DESCRIPTION
## Summary

- Adds commands for managing checklist items (steps) within tasks via the Microsoft Graph [checklistItems API](https://learn.microsoft.com/en-us/graph/api/resources/checklistitem)
- Adds `--steps`/`-s` flag to `lst` command to display steps inline

## New commands

| Command | Usage | Description |
|---------|-------|-------------|
| `new-step` | `todocli new-step "list/task" "step text"` | Create a checklist item on a task |
| `list-steps` | `todocli list-steps "list/task"` | Display all checklist items for a task |
| `complete-step` | `todocli complete-step "list/task" "step or index"` | Mark a step as checked |
| `rm-step` | `todocli rm-step "list/task" "step or index"` | Delete a step from a task |

The `lst` command now accepts `-s`/`--steps` to show steps inline:

```
todocli lst "Shopping" -s
[0]  Buy groceries
    [x] Buy eggs
    [ ] Buy milk
[1]  Clean house
```

All commands support the `-l`/`--list` flag for explicit list specification.

## Changes

- **`todocli/models/checklistitem.py`** (new) — `ChecklistItem` data model with flexible datetime parsing for the checklistItems API format
- **`todocli/graphapi/wrapper.py`** — add `StepNotFoundByName`/`StepNotFoundByIndex` exceptions and 5 new API functions (`get_checklist_items`, `create_checklist_item`, `complete_checklist_item`, `delete_checklist_item`, `get_step_id`)
- **`todocli/cli.py`** — add 4 handler functions, 4 subparsers, `--steps` flag on `lst`, and exception handlers
- **`todocli/help_msg.py`** / **`README.md`** — document new commands
- **`tests/test_checklist_*.py`** (3 new files) — 26 new unit tests for model, wrapper, and CLI parsing

## Test plan

- [x] All 80 unit tests pass
- [x] `black --check` passes on all files
- [x] Manual test: `new-step`, `list-steps`, `complete-step` (by name and index), `rm-step` — all verified against live API
- [x] Manual test: `lst "list" -s` — displays steps inline with `[x]`/`[ ]` status

Closes #83

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>